### PR TITLE
fix: don't copy permissions with files

### DIFF
--- a/src/custom_theme.py
+++ b/src/custom_theme.py
@@ -206,7 +206,7 @@ class CustomPage(Gtk.Box):
         else:
             emoji = emoji_entry.get_label()
         theme_file = os.path.join(parent.data_dir, theme_type, (entry.get_text() + " " + emoji + ".css"))
-        shutil.copy2(src_file, theme_file)
+        shutil.copyfile(src_file, theme_file)
         with open(theme_file, "w") as file:
             file.write(src_file_text)
 

--- a/src/interface_to_shell_theme.py
+++ b/src/interface_to_shell_theme.py
@@ -37,7 +37,7 @@ def parse_gtk_theme(gtk_css, gnome_shell_css, theme_file):
     gnome_shell_theme_dir = os.path.join(GLib.getenv("HOST_XDG_DATA_HOME"), "themes")
     os.makedirs(os.path.join(gnome_shell_theme_dir, "rewaita/gnome-shell"), exist_ok=True)
     rewaita_theme_dir = os.path.join(gnome_shell_theme_dir, "rewaita/gnome-shell")
-    file = shutil.copy2(theme_file, os.path.join(rewaita_theme_dir, "gnome-shell.css"))
+    file = shutil.copyfile(theme_file, os.path.join(rewaita_theme_dir, "gnome-shell.css"))
     with open(file, "w") as f:
         f.write(gnome_shell_css)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -97,7 +97,7 @@ def parse_gtk_theme(gtk_css, gnome_shell_css, theme_file):
 
     gnome_shell_theme_dir = os.path.join(GLib.getenv("HOME"), ".local", "share", "themes", "rewaita", "gnome-shell")
     os.makedirs(gnome_shell_theme_dir, exist_ok=True)
-    file = shutil.copy2(theme_file, os.path.join(gnome_shell_theme_dir, "gnome-shell.css"))
+    file = shutil.copyfile(theme_file, os.path.join(gnome_shell_theme_dir, "gnome-shell.css"))
     with open(file, "w") as f:
         f.write(gnome_shell_css)
 

--- a/src/window.py
+++ b/src/window.py
@@ -72,10 +72,15 @@ class RewaitaWindow(Adw.ApplicationWindow):
         #Moves the themes in the app sources to Rewaita's data directory
         if(not os.path.exists(os.path.join(GLib.get_user_data_dir(), "light"))):
             print("Refreshing light themes")
-            shutil.copytree(os.path.join(os.path.dirname(os.path.abspath(__file__)), "light"), os.path.join(GLib.get_user_data_dir(), "light"))
+            # Use `copyfile` to avoid copying metadata of files, like ownership or read-only flags
+            shutil.copytree(os.path.join(os.path.dirname(os.path.abspath(__file__)), "light"), os.path.join(GLib.get_user_data_dir(), "light"), copy_function=shutil.copyfile)
+            # And ensure the directory itself is writable
+            os.chmod(os.path.join(GLib.get_user_data_dir(), "light"), 0o755);
         if(not os.path.exists(os.path.join(GLib.get_user_data_dir(), "dark"))):
             print("Refreshing dark themes")
-            shutil.copytree(os.path.join(os.path.dirname(os.path.abspath(__file__)), "dark"), os.path.join(GLib.get_user_data_dir(), "dark"))
+            # Ditto
+            shutil.copytree(os.path.join(os.path.dirname(os.path.abspath(__file__)), "dark"), os.path.join(GLib.get_user_data_dir(), "dark"), copy_function=shutil.copyfile)
+            os.chmod(os.path.join(GLib.get_user_data_dir(), "dark"), 0o755);
 
         delete = Gio.SimpleAction.new(name="trash")
         delete.connect("activate", delete_items, self.delete_button, self)


### PR DESCRIPTION
This causes issues when the permissions of the files that come packaged
with Rewaita are read-only, or otherwise not owned by the current user

I originally came across this when [Rewaita was being packaged in Nixpkgs](https://github.com/NixOS/nixpkgs/pull/433739/) and the CSS files copied over couldn't be updated when you changed themes - since Nix forces an RO flag on package files. I'd imagine this would happen in plenty of other environments, though
