### PR TITLE
Add support for left-side (start) window controls (Window Controls 'Colored' style)

### DIFF
--- a/src/themes/window-controls/colored.css
+++ b/src/themes/window-controls/colored.css
@@ -1,3 +1,15 @@
+windowcontrols.start:not(.colored):not(.macos):not(.default) > button.minimize > image {
+    color: @yellow_1;
+}
+
+windowcontrols.start:not(.colored):not(.macos):not(.default) > button.maximize > image {
+    color: @green_1;
+}
+
+windowcontrols.start:not(.colored):not(.macos):not(.default) > button.close > image {
+    color: @red_1;
+}
+
 windowcontrols.end:not(.colored):not(.macos):not(.default) > button.minimize > image {
     color: @yellow_1;
 }


### PR DESCRIPTION
Currently, the Colored style for window controls don't color the window control buttons that are put at the start of the header bar, unlike the MacOS style which does.

This PR adds in the necessary CSS to support coloring these starting buttons.

### Before this PR:
<img width="396" height="275" alt="image" src="https://github.com/user-attachments/assets/8420dd83-e963-4b6d-811a-b9c5da1f8742" />

### With this PR:
<img width="399" height="230" alt="image" src="https://github.com/user-attachments/assets/a14ee6ac-afd1-44e8-85cc-44feeeffa5ae" />

