### PR TITLE
Updated "About Rewaita" version info (in advance) from 1.0.4 to 1.0.6

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -51,7 +51,7 @@ class RewaitaApplication(Adw.Application):
         about = Adw.AboutDialog(application_name='Rewaita',
                                 application_icon='io.github.swordpuffin.rewaita',
                                 developer_name='Nathan Perlman',
-                                version='1.0.4',
+                                version='1.0.6',
                                 developers=['Nathan Perlman'],
                                 copyright='© 2025 Nathan Perlman')
         # Translators: Replace "translator-credits" with your name/username, and optionally an email or URL.


### PR DESCRIPTION
You forgot to update version info for 1.0.5 and it made me confused about which version I had installed haha. After this commit you won't have to worry about remembering for 1.0.6.