### PR TITLE
Update Catppuccin Macchiato 🌺.css

### DIFF
--- a/src/themes/dark/Catppuccin Macchiato 🌺.css
+++ b/src/themes/dark/Catppuccin Macchiato 🌺.css
@@ -57,9 +57,9 @@
 @define-color red_4 @flamingo;
 @define-color red_5 @rosewater;
 
-@define-color purple_1 @mauve;
-@define-color purple_2 @lavender;
-@define-color purple_3 @pink;
+@define-color purple_1 @pink;
+@define-color purple_2 @mauve;
+@define-color purple_3 @lavender;
 @define-color purple_4 @flamingo;
 @define-color purple_5 @rosewater;
 


### PR DESCRIPTION
Fixed pink and purple accent, where they're not actually showing their respective colour

I am not too sure _why_ purple_1 seems to be the colour pink accent use, but this seems to work.
Pink accent:
<img width="343" height="124" alt="image" src="https://github.com/user-attachments/assets/3523d08d-87f4-4f1b-a64b-81da890f2ec1" />
Purple accent:
<img width="343" height="124" alt="image" src="https://github.com/user-attachments/assets/a5e46ea3-a41f-4d2c-bf0a-852f4890cb42" />
