### PR TITLE
Add openSUSE installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ flatpak install io.github.swordpuffin.rewaita
 yay -s rewaita
 ```
 
+### openSUSE
+```bash
+# Tumbleweed
+sudo zypper ar -cfp 90 https://download.opensuse.org/repositories/home:/ericfrs/openSUSE_Tumbleweed/home:ericfrs.repo
+# Slowroll
+sudo zypper ar -cfp 90 https://download.opensuse.org/repositories/home:/ericfrs/openSUSE_Slowroll/home:ericfrs.repo
+
+sudo zypper ref
+sudo zypper in rewaita
+```
+
 
 # ✅ Permissions 
 ### Allow Flatpak to edit GTK3/4 themes


### PR DESCRIPTION
This PR adds installation instructions for openSUSE Tumbleweed and Slowroll.

The package is maintained here: https://build.opensuse.org/package/show/home:ericfrs/rewaita

It also includes a fix for the autostart functionality. The issue was that Rewaita tried to write the desktop entry to ~/.config/autostart, but the directory didn't exist yet. The patch creates the directory if needed and adapts the desktop entry for native installations.