### PR TITLE
Change firefox sidebar new tab button color

### DIFF
--- a/src/themes/firefox_gnome_theme.py
+++ b/src/themes/firefox_gnome_theme.py
@@ -140,7 +140,7 @@ checkbox:not(.treenode-checkbox) > .checkbox-check[checked] {{
 
 #sidebar-main > * #tabs-newtab-button:hover,
 #sidebar-main > * .tabs-newtab-button:hover {{
-  background-color: var(--card_bg_color) !important;
+  background-color: var(--dark_1) !important;
 }}
 
 #urlbar,


### PR DESCRIPTION
<img width="415" height="783" alt="Screenshot From 2026-05-19 20-47-44 (Edited)" src="https://github.com/user-attachments/assets/2cc3c578-3fd1-4e4f-8570-a83ed1f266a3" />

Modifies the Firefox Theme to give the new tab button a consistent background color, before the icon background was bright but the button itself was darker.

(this is on hover, the cursor just wasn't captured)