### PR TITLE
We use "COLOUR" in Australia. Added en_AU.po

### DIFF
--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -1,0 +1,531 @@
+# Translation template for Rewaita
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: rewaita\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-31 00:00+0000\n"
+"PO-Revision-Date: 2026-05-27 03:51+1000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: en_AU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
+
+#: data/io.github.swordpuffin.rewaita.desktop.in:2
+#: data/io.github.swordpuffin.rewaita.metainfo.xml.in:7
+msgid "Rewaita"
+msgstr "Rewaita"
+
+#: data/io.github.swordpuffin.rewaita.desktop.in:8
+msgid "gtk;adwaita;gnome;shell;theme"
+msgstr "gtk;adwaita;gnome;shell;theme"
+
+#: data/io.github.swordpuffin.rewaita.metainfo.xml.in:8
+msgid "Bring color to Adwaita"
+msgstr "Bring colour to Adwaita"
+
+#: data/io.github.swordpuffin.rewaita.metainfo.xml.in:10
+msgid ""
+"Rewaita is a utility to recolor Gtk4/Adwaita apps to popular color schemes"
+msgstr ""
+"Rewaita is a utility to recolour Gtk4/Adwaita apps to popular colour schemes"
+
+#: data/io.github.swordpuffin.rewaita.metainfo.xml.in:11
+msgid ""
+"Changes only affect GTK3/4 applications; Other libraries are NOT supported"
+msgstr ""
+"Changes only affect GTK3/4 applications; Other libraries are NOT supported"
+
+#: data/io.github.swordpuffin.rewaita.metainfo.xml.in:15
+msgid "Nathan Perlman"
+msgstr "Nathan Perlman"
+
+#: data/io.github.swordpuffin.rewaita.metainfo.xml.in:35
+msgid "Browsing through dark themes"
+msgstr "Browsing through dark themes"
+
+#: data/io.github.swordpuffin.rewaita.metainfo.xml.in:39
+msgid "Browsing through light themes"
+msgstr "Browsing through light themes"
+
+#. Translators: Replace "translator-credits" with your name/username, and optionally an email or URL.
+#: src/main.py:157
+msgid "translator-credits"
+msgstr "translator-credits"
+
+#: src/utils.py:127
+msgid " has been deleted"
+msgstr " has been deleted"
+
+#: src/widgets/custom_theme_page.py:210
+msgid " has been saved"
+msgstr " has been saved"
+
+#: src/utils.py:137
+msgid "Cancel"
+msgstr "Cancel"
+
+#: src/utils.py:134 src/utils.py:138
+msgid "Delete"
+msgstr "Delete"
+
+#: src/utils.py:135
+msgid ""
+"Are you sure you want to delete that theme?\n"
+"This cannot be undone."
+msgstr ""
+"Are you sure you want to delete that theme?\r\n"
+"This cannot be undone."
+
+#: src/image_modifier.py:98
+msgid "Please select a theme first"
+msgstr "Please select a theme first"
+
+#: src/widgets/loading_dialog.py:31
+msgid "This may take a moment"
+msgstr "This may take a moment"
+
+#: src/widgets/window_control_box.py:53
+msgid "Window Controls"
+msgstr "Window Controls"
+
+#: src/widgets/window_control_box.py:24
+msgid "Default"
+msgstr "Default"
+
+#: src/widgets/window_control_box.py:25
+msgid "Colored"
+msgstr "Coloured"
+
+#: src/widgets/window_control_box.py:26
+msgid "MacOS"
+msgstr "MacOS"
+
+#: src/widgets/window_control_box.py:27
+msgid "Breeze"
+msgstr "Breeze"
+
+#: src/widgets/window_control_box.py:28
+msgid "Hidden"
+msgstr "Hidden"
+
+#: src/widgets/window_control_box.py:29
+msgid "Mint"
+msgstr "Mint"
+
+#: src/widgets/custom_theme_page.py:140
+msgid "Accent Colors"
+msgstr "Accent Colours"
+
+#: src/widgets/custom_theme_page.py:141
+msgid "Main Colors"
+msgstr "Main Colours"
+
+#: src/widgets/custom_theme_page.py:142
+msgid "Success Colors"
+msgstr "Success Colours"
+
+#: src/widgets/custom_theme_page.py:143
+msgid "Destructive Colors"
+msgstr "Destructive Colours"
+
+#: src/widgets/custom_theme_page.py:144
+msgid "Warning Colors"
+msgstr "Warning Colours"
+
+#: src/widgets/custom_theme_page.py:145
+msgid "Interface Colors"
+msgstr "Interface Colours"
+
+#: src/widgets/custom_theme_page.py:146
+msgid "Named Colors"
+msgstr "Named Colours"
+
+#: src/widgets/custom_theme_page.py:151
+msgid "Theme name (required)"
+msgstr "Theme name (required)"
+
+#: src/widgets/custom_theme_page.py:155
+msgid "Theme Type"
+msgstr "Theme Type"
+
+#: src/widgets/custom_theme_page.py:156
+msgid "Light"
+msgstr "Light"
+
+#: src/widgets/custom_theme_page.py:157
+msgid "Dark"
+msgstr "Dark"
+
+#: src/widgets/wallpaper_dialog.py:56 src/widgets/custom_theme_page.py:164
+msgid "Save Folder"
+msgstr "Save Folder"
+
+#: src/widgets/custom_theme_page.py:177
+msgid "Save"
+msgstr "Save"
+
+#: src/widgets/custom_theme_page.py:182
+msgid "/* Enter any extra CSS here */"
+msgstr "/* Enter any extra CSS here */"
+
+#: src/widgets/extra_options_box.py:102
+msgid "Extra Options"
+msgstr "Extra Options"
+
+#: src/widgets/extra_options_box.py:67
+msgid "Transparency"
+msgstr "Transparency"
+
+#: src/widgets/extra_options_box.py:68
+msgid "Adds a transparency effect to all window backdrops"
+msgstr "Adds a transparency effect to all window backdrops"
+
+#: src/widgets/extra_options_box.py:73
+msgid "Window Borders"
+msgstr "Window Borders"
+
+#: src/widgets/extra_options_box.py:74
+msgid "Draws an accented border around the window"
+msgstr "Draws an accented border around the window"
+
+#: src/widgets/extra_options_box.py:79
+msgid "Sharp Corners"
+msgstr "Sharp Corners"
+
+#: src/widgets/extra_options_box.py:80
+msgid "Gives all elements square borders"
+msgstr "Gives all elements square borders"
+
+#: src/widgets/extra_options_box.py:85
+msgid "Force Light Text in Overview"
+msgstr "Force Light Text in Overview"
+
+#: src/widgets/extra_options_box.py:86
+msgid "Might be useful for Blur my Shell users"
+msgstr "Might be useful for Blur my Shell users"
+
+#: src/widgets/pref_page.py:27
+msgid "Preferences"
+msgstr "Preferences"
+
+#: src/widgets/pref_page.py:34
+msgid "Generate GTK-3.0 Theme"
+msgstr "Generate GTK-3.0 Theme"
+
+#: src/widgets/pref_page.py:34
+msgid "Highly recommended for all users"
+msgstr "Highly recommended for all users"
+
+#: src/widgets/pref_page.py:34
+msgid "Generate GNOME Shell Theme"
+msgstr "Generate GNOME Shell Theme"
+
+#: src/widgets/pref_page.py:34
+msgid "For GNOME users"
+msgstr "For GNOME users"
+
+#: src/widgets/pref_page.py:34
+msgid "Run in background"
+msgstr "Run in background"
+
+#: src/widgets/pref_page.py:34
+msgid "For users who swap between light/dark mode"
+msgstr "For users who swap between light/dark mode"
+
+#: src/widgets/pref_page.py:34
+msgid "Generate Firefox CSS Theme"
+msgstr "Generate Firefox CSS Theme"
+
+#: src/widgets/pref_page.py:34
+msgid "May conflict with existing theme"
+msgstr "May conflict with existing theme"
+
+#: src/widgets/theme_page.py:104 src/widgets/guide_dialog.ui:11
+msgid "User Guide"
+msgstr "User Guide"
+
+#: src/widgets/theme_page.py:110
+msgid "Tint Wallpaper"
+msgstr "Tint Wallpaper"
+
+#: src/widgets/theme_page.py:120
+msgid "Reset to default"
+msgstr "Reset to default"
+
+#: src/widgets/wallpaper_dialog.py:51
+msgid "Open File"
+msgstr "Open File"
+
+#: src/widgets/wallpaper_dialog.py:72
+msgid "Drop Image Here"
+msgstr "Drop Image Here"
+
+#: src/window.py:112
+msgid "Theming"
+msgstr "Theming"
+
+#: src/window.py:113
+msgid "Custom"
+msgstr "Custom"
+
+#: src/window.py:114
+msgid "Fine Tune"
+msgstr "Fine Tune"
+
+#: src/window.py:153
+msgid "Change GNOME shell theme to 'Rewaita' and reboot for full changes"
+msgstr "Change GNOME shell theme to 'Rewaita' and reboot for full changes"
+
+#: src/window.ui:27
+msgid "Main Menu"
+msgstr "Main Menu"
+
+#: src/window.ui:19
+msgid "Delete themes"
+msgstr "Delete themes"
+
+#: src/window.ui:71
+msgid "_Keyboard Shortcuts"
+msgstr "_Keyboard Shortcuts"
+
+#: src/window.ui:75
+msgid "_About Rewaita"
+msgstr "_About Rewaita"
+
+#: src/gtk_help-overlay.ui:11
+msgid "General"
+msgstr "General"
+
+#: src/gtk_help-overlay.ui:14
+msgid "Show Shortcuts"
+msgstr "Show Shortcuts"
+
+#: src/gtk_help-overlay.ui:20
+msgid "Quit"
+msgstr "Quit"
+
+#: src/widgets/guide_dialog.ui:15
+msgid "Getting Started"
+msgstr "Getting Started"
+
+#: src/widgets/guide_dialog.ui:16
+msgid ""
+"After setting a color scheme, go to GNOME Tweaks and set 'Rewaita' as the "
+"Shell theme. It will match the active scheme for visual continuity. This can "
+"be disabled in preferences."
+msgstr ""
+"After setting a colour scheme, go to GNOME Tweaks and set 'Rewaita' as the "
+"Shell theme. It will match the active scheme for visual continuity. This can "
+"be disabled in preferences."
+
+#: src/widgets/guide_dialog.ui:21
+msgid "Run the Flatpak Override Commands"
+msgstr "Run the Flatpak Override Commands"
+
+#: src/widgets/guide_dialog.ui:22
+msgid ""
+"This will ensure Flatpak applications are themed accordingly. See 'Flatpak "
+"Overrides' below for details."
+msgstr ""
+"This will ensure Flatpak applications are themed accordingly. See 'Flatpak "
+"Overrides' below for details."
+
+#: src/widgets/guide_dialog.ui:29
+msgid "Change the System Theme"
+msgstr "Change the System Theme"
+
+#: src/widgets/guide_dialog.ui:30
+msgid ""
+"Many Linux distributions will set some custom GTK theme by default. To "
+"prevent conflicts, change the application theme to default or 'Adwaita'."
+msgstr ""
+"Many Linux distributions will set some custom GTK theme by default. To "
+"prevent conflicts, change the application theme to default or 'Adwaita'."
+
+#: src/widgets/guide_dialog.ui:37
+msgid "Automatic Switching"
+msgstr "Automatic Switching"
+
+#: src/widgets/guide_dialog.ui:38
+msgid ""
+"Rewaita runs in the background to switch between light/dark mode and accent "
+"color changes. This can be disabled in preferences."
+msgstr ""
+"Rewaita runs in the background to switch between light/dark mode and accent "
+"color changes. This can be disabled in preferences."
+
+#: src/widgets/guide_dialog.ui:45
+msgid "Found a bug or want to contribute?"
+msgstr "Found a bug or want to contribute?"
+
+#: src/widgets/guide_dialog.ui:46
+msgid ""
+"Open an issue or pull request in the upstream repository. See the 'Get "
+"Involved' tab for details."
+msgstr ""
+"Open an issue or pull request in the upstream repository. See the 'Get "
+"Involved' tab for details."
+
+#: src/widgets/guide_dialog.ui:59
+msgid ""
+"Rewaita only styles GTK-3/4 applications; other UI toolkits will not be "
+"affected"
+msgstr ""
+"Rewaita only styles GTK-3/4 applications; other UI toolkits will not be "
+"affected"
+
+#: src/widgets/guide_dialog.ui:68
+msgid "Flatpak Overrides"
+msgstr "Flatpak Overrides"
+
+#: src/widgets/guide_dialog.ui:69
+msgid "Run these commands so Flatpak applications can use your theme."
+msgstr "Run these commands so Flatpak applications can use your theme."
+
+#: src/widgets/guide_dialog.ui:87 src/widgets/guide_dialog.ui:113
+#: src/widgets/guide_dialog.ui:203
+msgid "Copy to clipboard"
+msgstr "Copy to clipboard"
+
+#: src/widgets/guide_dialog.ui:130
+msgid "Firefox"
+msgstr "Firefox"
+
+#: src/widgets/guide_dialog.ui:133
+msgid "Apply Theme to Firefox"
+msgstr "Apply Theme to Firefox"
+
+#: src/widgets/guide_dialog.ui:134
+msgid ""
+"First, enable 'Generate Firefox CSS Theme' in the 'Fine Tune' tab. After "
+"that, follow the steps below to set it up."
+msgstr ""
+"First, enable 'Generate Firefox CSS Theme' in the 'Fine Tune' tab. After "
+"that, follow the steps below to set it up."
+
+#: src/widgets/guide_dialog.ui:139
+msgid "Step 1 — Set any theme"
+msgstr "Step 1 — Set any theme"
+
+#: src/widgets/guide_dialog.ui:140
+msgid "We will do all the heavy lifting."
+msgstr "We will do all the heavy lifting."
+
+#: src/widgets/guide_dialog.ui:147
+msgid "Step 2 — Firefox Gnome Theme (Optional)"
+msgstr "Step 2 — Firefox Gnome Theme (Optional)"
+
+#: src/widgets/guide_dialog.ui:148
+msgid ""
+"Rewaita is also compatible with the Firefox Gnome Theme, but the window "
+"controls will not be themed."
+msgstr ""
+"Rewaita is also compatible with the Firefox Gnome Theme, but the window "
+"controls will not be themed."
+
+#: src/widgets/guide_dialog.ui:152
+msgid "Get it"
+msgstr "Get it"
+
+#: src/widgets/guide_dialog.ui:234 src/widgets/guide_dialog.ui:277
+#: src/widgets/guide_dialog.ui:295
+msgid "Install"
+msgstr "Install"
+
+#: src/widgets/guide_dialog.ui:165
+msgid "Step 3 — Restart Firefox"
+msgstr "Step 3 — Restart Firefox"
+
+#: src/widgets/guide_dialog.ui:166
+msgid "Fully quit and relaunch Firefox for the changes to take effect."
+msgstr "Fully quit and relaunch Firefox for the changes to take effect."
+
+#: src/widgets/guide_dialog.ui:221
+msgid "GNOME Shell"
+msgstr "GNOME Shell"
+
+#: src/widgets/guide_dialog.ui:225
+msgid "Apply the Shell Theme"
+msgstr "Apply the Shell Theme"
+
+#: src/widgets/guide_dialog.ui:226
+msgid ""
+"Rewaita includes a matching GNOME Shell theme. Follow these steps to enable "
+"it."
+msgstr ""
+"Rewaita includes a matching GNOME Shell theme. Follow these steps to enable "
+"it."
+
+#: src/widgets/guide_dialog.ui:231
+msgid "Step 1 — Install the User Themes extension"
+msgstr "Step 1 — Install the User Themes extension"
+
+#: src/widgets/guide_dialog.ui:232
+msgid ""
+"GNOME Shell requires the User Themes extension to load custom shell themes."
+msgstr ""
+"GNOME Shell requires the User Themes extension to load custom shell themes."
+
+#: src/widgets/guide_dialog.ui:249
+msgid "Step 2 — Set any theme"
+msgstr "Step 2 — Set any theme"
+
+#: src/widgets/guide_dialog.ui:250
+msgid ""
+"Rewaita will generate the theme automatically and place it in ~/.local/share/"
+"themes. This can be disabled in preferences."
+msgstr ""
+"Rewaita will generate the theme automatically and place it in ~/.local/share/"
+"themes. This can be disabled in preferences."
+
+#: src/widgets/guide_dialog.ui:257
+msgid "Step 3 — Select it in GNOME Tweaks"
+msgstr "Step 3 — Select it in GNOME Tweaks"
+
+#: src/widgets/guide_dialog.ui:258
+msgid ""
+"Open GNOME Tweaks → Appearance → Shell and choose Rewaita from the dropdown."
+msgstr ""
+"Open GNOME Tweaks → Appearance → Shell and choose Rewaita from the dropdown."
+
+#: src/widgets/guide_dialog.ui:266
+msgid "Useful Extensions"
+msgstr "Useful Extensions"
+
+#: src/widgets/guide_dialog.ui:267
+msgid "These extensions pair well with Rewaita."
+msgstr "These extensions pair well with Rewaita."
+
+#: src/widgets/guide_dialog.ui:273
+msgid "Application menu for GNOME Shell."
+msgstr "Application menu for GNOME Shell."
+
+#: src/widgets/guide_dialog.ui:291
+msgid "Moves the overview dash into a persistent, themeable dock."
+msgstr "Moves the overview dash into a persistent, themeable dock."
+
+#: src/widgets/guide_dialog.ui:312
+msgid "Get Involved"
+msgstr "Get Involved"
+
+#: src/widgets/guide_dialog.ui:338
+msgid "Contribute to Rewaita"
+msgstr "Contribute to Rewaita"
+
+#: src/widgets/guide_dialog.ui:350
+msgid ""
+"Anyone, regardless of experience or background, is welcome to join. Open an "
+"issue to report bugs or suggest themes, or submit a pull request to "
+"contribute directly."
+msgstr ""
+"Anyone, regardless of experience or background, is welcome to join. Open an "
+"issue to report bugs or suggest themes, or submit a pull request to "
+"contribute directly."
+
+#: src/widgets/guide_dialog.ui:360
+msgid "Open in Browser"
+msgstr "Open in Browser"


### PR DESCRIPTION
"Rewaita is also compatible with the Firefox Gnome Theme, but the window controls will not be themed."

Are you absolutely sure about this? It works fine for me, is this maybe an issue exclusive to Flatpak Firefox?